### PR TITLE
fix: lit_split respects keepempty

### DIFF
--- a/lua/rainbow_csv/fns.lua
+++ b/lua/rainbow_csv/fns.lua
@@ -201,7 +201,7 @@ end
 local function lit_split(str, sep, keepempty)
 	-- internal use of lit_split relies on plain = true to avoid calling escape()
 	-- a bunch of times
-	if keepempty ~= nil then
+	if keepempty == nil then
 		return vim_split(str, sep, { plain = true, trimempty = true })
 	end
 	return vim_split(str, sep, { plain = true, trimempty = not keepempty })


### PR DESCRIPTION
Previously the option was ignored, causing blank leading/trailing columns to be disregarded in various contexts.